### PR TITLE
install: fix syntax errors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -47,11 +47,11 @@ guess_system_package_manager(){
         PIP_INSTALL_CMD="pip install --user"
     fi
 
-    if [ $SYSTEM_PACKAGE_TYPE == "rpm" ]; then
+    if [ "$SYSTEM_PACKAGE_TYPE" == "rpm" ]; then
         SYSTEM_PACKAGE_SET="gvim ctags cppcheck git wget pcre-devel python-pip python-devel clang-devel clang-libs clang-tools-extra"
-    elif [ $SYSTEM_PACKAGE_TYPE == "deb" ]; then
+    elif [ "$SYSTEM_PACKAGE_TYPE" == "deb" ]; then
         SYSTEM_PACKAGE_SET="vim-gnome ctags cppcheck git wget libpcre3 libpcre3-dev python-pip python-dev libclang-dev clang-tidy"
-    elif [ $SYSTEM_PACKAGE_TYPE == "archpkg" ] || [ $SYSTEM_PACKAGE_TYPE == "ebuild" ]; then
+    elif [ "$SYSTEM_PACKAGE_TYPE" == "archpkg" ] || [ "$SYSTEM_PACKAGE_TYPE" == "ebuild" ]; then
         SYSTEM_PACKAGE_SET="gvim ctags cppcheck git wget pcre python-pip python clang"
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ guess_system_package_manager(){
         SYSTEM_PACKAGE_SET="gvim ctags cppcheck git wget pcre-devel python-pip python-devel clang-devel clang-libs clang-tools-extra"
     elif [ $SYSTEM_PACKAGE_TYPE == "deb" ]; then
         SYSTEM_PACKAGE_SET="vim-gnome ctags cppcheck git wget libpcre3 libpcre3-dev python-pip python-dev libclang-dev clang-tidy"
-    elif [ $SYSTEM_PACKAGE_TYPE == "archpkg" || $SYSTEM_PACKAGE_TYPE == "ebuild" ]; then
+    elif [ $SYSTEM_PACKAGE_TYPE == "archpkg" ] || [ $SYSTEM_PACKAGE_TYPE == "ebuild" ]; then
         SYSTEM_PACKAGE_SET="gvim ctags cppcheck git wget pcre python-pip python clang"
     fi
 


### PR DESCRIPTION
1. "[" expressions unfortunately do not support nested "||" or commands. Instead, we can conjuct several "[" expressions wits "||"-s
2. when the variable is empty or is set to "", it expands to nothing, making expressions like `$var == ""` incorrect, because it expands to ` == ""`. Enquoting fixes the issue