### PR TITLE
Fixed dependencies list

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -13,11 +13,11 @@
 * Internet connection
 
 In `fedora`-based distributions, one may install the requirements by running:
-* `sudo dnf --refresh install @development-tools gvim python2 git clang-devel`
+* `sudo dnf --refresh install @development-tools python2 git clang-devel`
 
 In `debian`-based distributions, one may install the requirements by running:
 * `sudo apt-get update`
-* `sudo apt-get install build-essential vim-gnome python2.7 git libclang-dev`
+* `sudo apt-get install build-essential python2.7 git libclang-dev`
 
 # Installation
 Default installation path is set to `/opt/yavide`. To use different installation directory, provide it as a command line argument to `install.sh` script.

--- a/install.sh
+++ b/install.sh
@@ -48,11 +48,11 @@ guess_system_package_manager(){
     fi
 
     if [ "$SYSTEM_PACKAGE_TYPE" == "rpm" ]; then
-        SYSTEM_PACKAGE_SET="gvim ctags cppcheck git wget pcre-devel python-pip python-devel clang-devel clang-libs clang-tools-extra"
+        SYSTEM_PACKAGE_SET="ctags cppcheck git wget pcre-devel python-pip python-devel clang-devel clang-libs clang-tools-extra"
     elif [ "$SYSTEM_PACKAGE_TYPE" == "deb" ]; then
-        SYSTEM_PACKAGE_SET="vim-gnome ctags cppcheck git wget libpcre3 libpcre3-dev python-pip python-dev libclang-dev clang-tidy"
+        SYSTEM_PACKAGE_SET="ctags cppcheck git wget libpcre3 libpcre3-dev python-pip python-dev libclang-dev clang-tidy"
     elif [ "$SYSTEM_PACKAGE_TYPE" == "archpkg" ] || [ "$SYSTEM_PACKAGE_TYPE" == "ebuild" ]; then
-        SYSTEM_PACKAGE_SET="gvim ctags cppcheck git wget pcre python-pip python clang"
+        SYSTEM_PACKAGE_SET="ctags cppcheck git wget pcre python-pip python clang"
     fi
 
     PIP_PACKAGE_SET="clang"


### PR DESCRIPTION
gvim and vim-gnome packages should not be marked as dependencies and installed by install.sh script cause those might not be compiled with python support which may end up with issues like #28 or #76.
Requirements (https://github.com/JBakamovic/yavide/blob/master/docs/INSTALL.md#requirements) page shall also be updated to do not mention installing vim-gnome/gvim from official packages (at least on Ubuntu I've checked and following that path ends up with errors).